### PR TITLE
restart unity after windows were restored

### DIFF
--- a/offscreen-window-restore.sh
+++ b/offscreen-window-restore.sh
@@ -23,3 +23,6 @@ wmctrl -l -G | awk -v h=$height '{
 		}
 	}
 }'
+
+# restart unity to avoid problems with restored windows (unclickable areas)
+unity


### PR DESCRIPTION
some areas of restored windows were not clickable. restarting unity solved that problem
